### PR TITLE
Fix treehash bug when running on maCOS

### DIFF
--- a/bin/verify_treehashes
+++ b/bin/verify_treehashes
@@ -31,12 +31,14 @@ for YAML_PATH in ${YAML_PATHS[@]}; do
         PIPELINE_ENCRYPTED_TREEHASH="$(cut -d'&' -f3 <<<"${TRIPLET}" | tr -d '"')"
         PIPELINE_TREEHASH_FILESOURCE="$(cut -d'&' -f4 <<<"${TRIPLET}" | tr -d '"')"
 
-        # Write embedded encrypted treehash out to file
+        # Compare decrypted treehash with calculated treehash
         PIPELINE_DECRYPTED_TREEHASH="$(base64dec <<<"${PIPELINE_ENCRYPTED_TREEHASH}" | decrypt_aes "${REPO_KEY_PATH}")"
         if [[ "${PIPELINE_DECRYPTED_TREEHASH}" == "${PIPELINE_TREEHASH}" ]]; then
             echo "[${YAML_PATH}] -> ${PIPELINE_PATH}: ✔️"
         else
             echo "[${YAML_PATH}] -> ${PIPELINE_PATH}: ❌"
+            echo "    Expected: ${PIPELINE_DECRYPTED_TREEHASH}"
+            echo "  Calculated: ${PIPELINE_TREEHASH}"
             SHOULD_FAIL="true"
         fi
     done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -43,7 +43,17 @@ function vcat() {
 if [[ -z "$(which openssl 2>/dev/null)" ]]; then
     die "'openssl' tool required!"
 elif [[ "$(openssl version)" == "LibreSSL 2"* ]]; then
-    die "'openssl' tool outdated!  If you're on macOS, try 'brew install openssl', then add it to the PATH!"
+    # Homebrew doesn't like to link `openssl`, so let's manually pluck out a homebrew-installed `openssl`, if it exists
+    HOMEBREW_PREFIX="$(dirname $(dirname $(which brew 2>/dev/null)))"
+    for OPENSSL_DIR in ${HOMEBREW_PREFIX}/Cellar/openssl\@3/*; do
+        if [[ -f "${OPENSSL_DIR}/bin/openssl" ]]; then
+            echo " -> Homebrew OpenSSL installation found at ${OPENSSL_DIR}"
+            PATH="${OPENSSL_DIR}/bin:${PATH}"
+        fi
+    done
+    if [[ "$(openssl version)" == "LibreSSL 2"* ]]; then
+        die "'openssl' tool outdated!  If you're on macOS, try 'brew install openssl@3'."
+    fi
 fi
 
 # Figure out which shasum program to use

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -297,7 +297,7 @@ function calc_treehash() {
         done
     done
 
-    calc_shasum <<< ${DIR_HASHES[@]}
+    calc_shasum <<< "${DIR_HASHES[@]}"
 }
 
 


### PR DESCRIPTION
I found a small bug that (unfortunately) effects how our treehashes are calculated; so once this is released, it'll break all current treehashes.  It has to do with whitespace handling; this makes it more consistent, but we'll just have to re-sign all treehashes once they update to this version of cryptic.