### PR TITLE
Don't attempt to shred missing files

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -68,7 +68,11 @@ fi
 # Figure out the best way to securely delete something
 if [[ -n "$(which shred 2>/dev/null)" ]]; then
     function secure_delete() {
-        shred -u "$*"
+        for f in "$@"; do
+            if [[ -e "${f}" ]]; then
+                shred -u "${f}"
+            fi
+        done
     }
 elif [[ "$(uname)" == "Darwin" ]] || [[ "$(uname)" == *BSD ]]; then
     function secure_delete() {


### PR DESCRIPTION
`shred` can apparently fail if a file is missing; so don't bother to `shred` if the file doesn't exist.