### PR TITLE
Gitignore the repo and agent private keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
+.DS_Store
+
+# Ignore the unencrypted repo_key
+repo_key
+repo.key
+
+# Ignore any agent keys (public or private) we have stored
+agent_key*
+agent.key*
+
+# Ignore IDE files
 .vscode/


### PR DESCRIPTION
Just in the off chance that someone has a local clone of this repo, and accidentally copies a private key into it.