### PR TITLE
Use env to detect bash.

### DIFF
--- a/bin/create_agent_keypair
+++ b/bin/create_agent_keypair
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## This script creates an "agent keypair".  The private key is stored on an agent, and is used to
 ## encrypt/decrypt a per-repository symmetric key.

--- a/hooks/environment.agent
+++ b/hooks/environment.agent
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## post-checkout hook: This hook performs the actual decryption of secrets
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## post-command hook: This hook implements treehash verification and pipeline launching
 


### PR DESCRIPTION
Without it, `/bin/bash` can resolve to macOS' very old Bash, which doesn't support the `globstar` used in here.

Please ASAP merge and tag this, because the Julia workers are broken because of this: https://buildkite.com/julialang/julia-master/builds/41488#0192bf05-caf1-46b5-8eca-698816f765b9
I wonder if we shouldn't move this plug-in to JuliaCI so that it's easier to admin?