### PR TITLE
Don't fail silently if the pipeline tries to use the cryptic plugin but we aren't privileged

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -9,7 +9,10 @@ source "${CRYPTIC_REPO}/lib/common.sh"
 # If we're not authorized, quit out immediately
 if [[ "${BUILDKITE_PLUGIN_CRYPTIC_PRIVILEGED:-false}" != "true" ]]; then
     echo "Exiting immediately, as we're not privileged"
-    exit 0
+
+    # In this case, we don't want to fail silently.
+    # So we intentionally exit with non-zero exit code.
+    exit 1
 fi
 
 # Receive keys from agent environment hook

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -9,7 +9,10 @@ source "${CRYPTIC_REPO}/lib/common.sh"
 # If we're not authorized, quit out immediately
 if [[ "${BUILDKITE_PLUGIN_CRYPTIC_PRIVILEGED:-false}" != "true" ]]; then
     echo "Exiting immediately, as we're not privileged"
-    exit 0
+
+    # In this case, we don't want to fail silently.
+    # So we intentionally exit with non-zero exit code.
+    exit 1
 fi
 
 # If the command hook failed, quit out immediately


### PR DESCRIPTION
In this job (https://buildkite.com/julialang/julia-master/builds/49506#01985707-ca66-4ea8-bb8f-630ca773419c), the job has a "success" (green) status, but cryptic did not run successfully.

We should surface that kind of error in a more visible way.